### PR TITLE
Fix padding error

### DIFF
--- a/crypt.py
+++ b/crypt.py
@@ -13,7 +13,13 @@ class AESCipher:
     
         #need to make our string divisible by 16 for AES encryption
     def pad(self, s):
-        return s + b"\0" * (AES.block_size - len(s) % AES.block_size)
+        n = AES.block_size - len(s) % AES.block_size
+        n = AES.block_size if n == 0 else n
+        return s + chr(n) * n
+
+    def remove_pad(self, m):
+        n = int(m[-1].encode('hex'), AES.block_size)
+        return m[: -1 * n]
         
         #encrypts plaintext and generates IV (initialization vector)
     def encrypt(self, plaintext):
@@ -27,7 +33,7 @@ class AESCipher:
         iv = ciphertext[:AES.block_size]
         cipher = AES.new(self.key, AES.MODE_CBC, iv)
         plaintext = cipher.decrypt(ciphertext[AES.block_size:])
-        return plaintext.rstrip(b"\0")
+        return self.remove_pad(plaintext)
     
         #encrypts a file and returns a comment to be posted
     def encrypt_file(self, file_path):


### PR DESCRIPTION
The current padding has the potential to remove user data.
For instance if a user has the raw bytes 0x8500, it will be padded with the bytes "0x00 ... 00", but when the padding is removed it will lose the original trailing zeros and become 0x85.

The standard way to fix this is to implement PKCS#7 padding, where the padded bytes equal the number of bytes added, and there is always at least 1 byte added. Even if the original data is divisible by the aes block size length, you pad by the block size, so you know exactly how many bytes to remove.